### PR TITLE
Patch File Name Sanitization Bug and Deprecation Warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "evaporate"
-version = "0.1.2"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "evaporate"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evaporate"
-version = "0.1.2"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evaporate"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -66,7 +66,8 @@ fn fetch(manifest: &Manifest) -> Result<HashMap<String, Vec<Message>>> {
 	while let Some(row) = rows.next()? {
 		let name: String = row.get(3)?;
 		let timestamp = Local.from_utc_datetime(
-			&NaiveDateTime::from_timestamp(row.get::<_, i64>(2)? + TIMESTAMP_OFFSET, 0)
+			&NaiveDateTime::from_timestamp_opt(row.get::<_, i64>(2)? + TIMESTAMP_OFFSET, 0)
+				.expect("! invalid timestamp found in database !")
 		);
 
 		let message = Message {
@@ -95,7 +96,7 @@ pub fn extract_to<P: AsRef<Path>>(path: P, manifest: &Manifest) -> Result<()> {
 		}
 
 		let mut file = File::create(path.join(&name).with_extension("txt"))?;
-		let mut last_timestamp = Local.timestamp(0, 0);
+		let mut last_timestamp = Local.timestamp_opt(0, 0).unwrap();
 
 		for message in conversation {
 			if message.timestamp - last_timestamp > Duration::hours(2) {


### PR DESCRIPTION
This pull request primarily fixes the bug in issue #3 as well as fixing deprecation warnings from `chrono`.
- Sanitizes output file names as described in #3:
  1. Invalid characters (depending on the file system / OS) will be replaced with a dash ('-').
  2. Directory traversal specifiers such as . and .., as well as empty names, will be replaced with "Unknown".
  3. Repeated first + last names for contacts will be enumerated, starting at 1 for the first repeated name.

- Switches to using `chrono::DateTime<Local>` over the deprecated `chrono::Date<Local>` and associated functions.